### PR TITLE
Print public job link to stdout on failure in both junit and testng

### DIFF
--- a/junit/src/main/java/com/saucelabs/junit/SauceOnDemandTestWatcher.java
+++ b/junit/src/main/java/com/saucelabs/junit/SauceOnDemandTestWatcher.java
@@ -97,6 +97,10 @@ public class SauceOnDemandTestWatcher extends TestWatcher {
             updates.put("passed", false);
             Utils.addBuildNumberToUpdate(updates);
             sauceREST.updateJobInfo(sessionIdProvider.getSessionId(), updates);
+
+            // get, and print to StdOut, the link to the job
+            String authLink = sauceREST.getPublicJobLink(sessionIdProvider.getSessionId());
+            System.out.println("Job link: " + authLink);
         }
     }
 

--- a/testng/src/main/java/com/saucelabs/testng/SauceOnDemandTestListener.java
+++ b/testng/src/main/java/com/saucelabs/testng/SauceOnDemandTestListener.java
@@ -94,6 +94,7 @@ public class SauceOnDemandTestListener extends TestListenerAdapter {
     public void onTestFailure(ITestResult tr) {
         super.onTestFailure(tr);
         markJobAsFailed();
+        printPublicJobLink();
     }
 
     private void markJobAsFailed() {
@@ -108,6 +109,15 @@ public class SauceOnDemandTestListener extends TestListenerAdapter {
             }
         }
 
+    }
+
+    private void printPublicJobLink() {
+        if (this.sauceREST != null && sessionIdProvider != null) {
+            String sessionId = sessionIdProvider.getSessionId();
+            String authLink = this.sauceREST.getPublicJobLink(sessionId);
+            // String authLink = "test";
+            System.out.println("Job link: " + authLink);
+        }
     }
 
 


### PR DESCRIPTION
This adds the printing of public job links in both junit and testng through the sauce-java framework.

It relies upon the update to saucerest-java, and so cannot be merged with master until that is in the Maven repository.

@jlipps
