### PR TITLE
Remove reference to SNAPSHOT in the testng/pom.xml

### DIFF
--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sauce_java</artifactId>
         <groupId>com.saucelabs</groupId>
-        <version>2.1.21-SNAPSHOT</version>
+        <version>2.1.20</version>
     </parent>
     <artifactId>sauce_testng</artifactId>
     <name>sauce_testng</name>


### PR DESCRIPTION
This was pointing to 2.1.21-SNAPSHOT - changed to point to 2.1.20