### PR TITLE
Refactored SauceOnDemandListener and a minor test update.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,29 +6,13 @@
 *.ear
 
 .DS_Store
-.idea
-junit/sauce_junit.iml
-
-testng/sauce_testng.iml
+.idea/
 
 junit/atlassian-ide-plugin.xml
 
 target
 
-sauce_java.iml
-
-sauce_java.iml
-
-common/sauce_java_common.iml
-
-quickstart-archetype/quickstart-seleniumrc-junit/quickstart-seleniumrc-junit.iml
-
-quickstart-archetype/quickstart-seleniumrc-testng/quickstart-seleniumrc-testng.iml
-
-quickstart-archetype/quickstart-archetype.iml
-
-quickstart-archetype/quickstart-webdriver-junit/quickstart-webdriver-junit.iml
+*.iml
 
 atlassian-ide-plugin.xml
 
-quickstart-archetype/quickstart-webdriver-testng/quickstart-webdriver-testng.iml

--- a/quickstart-archetype/quickstart-webdriver-junit/src/main/resources/archetype-resources/src/test/java/SampleSauceTest.java
+++ b/quickstart-archetype/quickstart-webdriver-junit/src/main/resources/archetype-resources/src/test/java/SampleSauceTest.java
@@ -135,13 +135,13 @@ public class SampleSauceTest implements SauceOnDemandSessionIdProvider {
     }
 
     /**
-     * Runs a simple test verifying the title of the amazon.com homepage.
+     * Runs a simple test verifying the title of the sauce labs test page.
      * @throws Exception
      */
     @Test
     public void amazon() throws Exception {
-        driver.get("http://www.amazon.com/");
-        assertEquals("Amazon.com: Online Shopping for Electronics, Apparel, Computers, Books, DVDs & more", driver.getTitle());
+        driver.get("https://saucelabs.com/test/guinea-pig");
+        assertEquals("I am a page title - Sauce Labs", driver.getTitle());
     }
 
     /**

--- a/testng/src/main/java/com/saucelabs/testng/SauceOnDemandTestListener.java
+++ b/testng/src/main/java/com/saucelabs/testng/SauceOnDemandTestListener.java
@@ -115,7 +115,7 @@ public class SauceOnDemandTestListener extends TestListenerAdapter {
         try {
             Map<String, Object> updates = new HashMap<String, Object>();
             updates.put("passed", passed);
-            Utils.addBuildNumberToUpdate(updates);
+            //Utils.addBuildNumberToUpdate(updates);
             sauceREST.updateJobInfo(sessionId, updates);
         } catch (Exception e) {
             e.printStackTrace();

--- a/testng/src/main/java/com/saucelabs/testng/SauceOnDemandTestListener.java
+++ b/testng/src/main/java/com/saucelabs/testng/SauceOnDemandTestListener.java
@@ -15,10 +15,9 @@ import java.util.Map;
  * Test Listener that providers helper logic for TestNG tests.  Upon startup, the class
  * will store any SELENIUM_* environment variables (typically set by a Sauce OnDemand CI
  * plugin) as system parameters, so that they can be retrieved by tests as parameters.
- * <p/>
- * TODO how to specify whether to download log/video?
+ * <p/>*
  *
- * @author Ross Rowe
+ * @author Ross Rowe / Mehmet Gerceker
  */
 public class SauceOnDemandTestListener extends TestListenerAdapter {
 
@@ -26,12 +25,6 @@ public class SauceOnDemandTestListener extends TestListenerAdapter {
     private static final String SELENIUM_PLATFORM = "SELENIUM_PLATFORM";
     private static final String SELENIUM_VERSION = "SELENIUM_VERSION";
     private static final String SELENIUM_IS_LOCAL = "SELENIUM_IS_LOCAL";
-
-    /**
-     * The underlying {@link com.saucelabs.common.SauceOnDemandSessionIdProvider} instance which contains the Selenium session id.  This is typically
-     * the unit test being executed.
-     */
-    private SauceOnDemandSessionIdProvider sessionIdProvider;
 
     /**
      * The instance of the Sauce OnDemand Java REST API client.
@@ -87,13 +80,6 @@ public class SauceOnDemandTestListener extends TestListenerAdapter {
             return;
         }
 
-        if (verboseMode && result.getInstance() instanceof SauceOnDemandSessionIdProvider) {
-            this.sessionIdProvider = (SauceOnDemandSessionIdProvider) result.getInstance();
-            //log the session id to the system out
-            if (sessionIdProvider.getSessionId() != null) {
-                System.out.println(String.format("SauceOnDemandSessionID=%1$s job-name=%2$s", sessionIdProvider.getSessionId(), result.getMethod().getMethodName()));
-            }
-        }
         SauceOnDemandAuthentication sauceOnDemandAuthentication;
         if (result.getInstance() instanceof SauceOnDemandAuthenticationProvider) {
             //use the authentication information provided by the test class
@@ -111,36 +97,42 @@ public class SauceOnDemandTestListener extends TestListenerAdapter {
      */
     @Override
     public void onTestFailure(ITestResult tr) {
+        SauceOnDemandSessionIdProvider sessionIdProvider = (SauceOnDemandSessionIdProvider) tr.getInstance();
+        if (sessionIdProvider != null && sauceREST != null) {
+            String sessionId = sessionIdProvider.getSessionId();
+            markJobStatus(sessionId, false);
+            printOutSessionID(sessionId, tr.getMethod().getMethodName());
+            printPublicJobLink(sessionId);
+        }
         super.onTestFailure(tr);
         if (isLocal) {
             return;
         }
-
-        markJobAsFailed();
-        printPublicJobLink();
     }
 
-    private void markJobAsFailed() {
+    private void markJobStatus(String sessionId, boolean passed) {
 
-        if (this.sauceREST != null && sessionIdProvider != null) {
-            String sessionId = sessionIdProvider.getSessionId();
-            if (sessionId != null) {
-                Map<String, Object> updates = new HashMap<String, Object>();
-                updates.put("passed", false);
-                Utils.addBuildNumberToUpdate(updates);
-                sauceREST.updateJobInfo(sessionId, updates);
-            }
+        try {
+            Map<String, Object> updates = new HashMap<String, Object>();
+            updates.put("passed", passed);
+            Utils.addBuildNumberToUpdate(updates);
+            sauceREST.updateJobInfo(sessionId, updates);
+        } catch (Exception e) {
+            e.printStackTrace();
         }
 
     }
 
-    private void printPublicJobLink() {
-        if (verboseMode && this.sauceREST != null && sessionIdProvider != null) {
-            String sessionId = sessionIdProvider.getSessionId();
+    private void printPublicJobLink(String sessionId) {
+        if (verboseMode) {
             String authLink = this.sauceREST.getPublicJobLink(sessionId);
             // String authLink = "test";
             System.out.println("Job link: " + authLink);
         }
+    }
+
+    private void printOutSessionID(String sessionId, String testName) {
+        System.out.println(String.format("SauceOnDemandSessionID=%1$s job-name=%2$s", sessionId, testName));
     }
 
     /**
@@ -148,25 +140,15 @@ public class SauceOnDemandTestListener extends TestListenerAdapter {
      */
     @Override
     public void onTestSuccess(ITestResult tr) {
+        SauceOnDemandSessionIdProvider sessionIdProvider = (SauceOnDemandSessionIdProvider) tr.getInstance();
+        String sessionId = sessionIdProvider.getSessionId();
+        printOutSessionID(sessionId, tr.getMethod().getMethodName());
+        markJobStatus(sessionId, true);
         super.onTestSuccess(tr);
         if (isLocal) {
             return;
         }
 
-        markJobAsPassed();
     }
 
-    private void markJobAsPassed() {
-
-        if (this.sauceREST != null && sessionIdProvider != null) {
-            String sessionId = sessionIdProvider.getSessionId();
-            if (sessionId != null) {
-                Map<String, Object> updates = new HashMap<String, Object>();
-                updates.put("passed", true);
-                Utils.addBuildNumberToUpdate(updates);
-                sauceREST.updateJobInfo(sessionId, updates);
-            }
-        }
-
-    }
 }

--- a/testng/src/test/java/com/saucelabs/testng/SampleSauceTest.java
+++ b/testng/src/test/java/com/saucelabs/testng/SampleSauceTest.java
@@ -4,20 +4,15 @@ package com.saucelabs.testng;
  * @author Russ Rowe / Mehmet Gerceker
  */
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.openqa.selenium.WebDriver;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-import java.io.*;
 import java.lang.reflect.Method;
 import java.util.logging.Level;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 
 
 /**

--- a/testng/src/test/java/com/saucelabs/testng/SampleSauceTest.java
+++ b/testng/src/test/java/com/saucelabs/testng/SampleSauceTest.java
@@ -1,48 +1,32 @@
 package com.saucelabs.testng;
 
 /**
- * @author Ross Rowe
+ * @author Russ Rowe / Mehmet Gerceker
  */
 
-import com.saucelabs.common.SauceOnDemandAuthentication;
-import com.saucelabs.common.SauceOnDemandSessionIdProvider;
-import org.openqa.selenium.Platform;
+import org.apache.commons.lang3.tuple.Pair;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import java.io.*;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 
 /**
  * Simple TestNG test which demonstrates being instantiated via a DataProvider in order to supply multiple browser combinations.
  *
- * @author Ross Rowe
+ * @author Russ Rowe / Mehmet Gerceker
  */
 @Listeners({SauceOnDemandTestListener.class})
-public class SampleSauceTest implements SauceOnDemandSessionIdProvider, SauceOnDemandAuthenticationProvider {
-
-    /**
-     * Constructs a {@link com.saucelabs.common.SauceOnDemandAuthentication} instance using the supplied user name/access key.  To use the authentication
-     * supplied by environment variables or from an external file, use the no-arg {@link com.saucelabs.common.SauceOnDemandAuthentication} constructor.
-     */
-    public SauceOnDemandAuthentication authentication = new SauceOnDemandAuthentication();
-
-    private ThreadLocal<WebDriver> webDriver = new ThreadLocal<WebDriver>();
-
-    private ThreadLocal<String> sessionId = new ThreadLocal<String>();
-
-    private static final Logger logger = Logger.getLogger(SampleSauceTest.class.getName());
-
+public class SampleSauceTest extends SauceTestBase {
 
     /**
      * Simple hard-coded DataProvider that explicitly sets the browser combinations to be used.
@@ -53,32 +37,10 @@ public class SampleSauceTest implements SauceOnDemandSessionIdProvider, SauceOnD
     @DataProvider(name = "hardCodedBrowsers", parallel = true)
     public static Object[][] sauceBrowserDataProvider(Method testMethod) {
         return new Object[][]{
-                new Object[]{"internet explorer", "11", "Windows 2012"},
-                new Object[]{"safari", "6", "Mac OS 10.8"},
+            new Object[]{"chrome", "43", "Windows 2012"},
+            new Object[]{"firefox", "42", "Linux"},
         };
     }
-
-    /**
-     * Creates a new {@link RemoteWebDriver} instance which is configured
-     * @param browser
-     * @param version
-     * @param os
-     * @return
-     * @throws MalformedURLException
-     */
-    private WebDriver createDriver(String browser, String version, String os) throws MalformedURLException {
-
-        DesiredCapabilities capabilities = new DesiredCapabilities();
-        capabilities.setBrowserName(browser);
-        capabilities.setCapability("version", version);
-        capabilities.setCapability("platform", os);
-        webDriver.set(new RemoteWebDriver(
-                new URL("http://" + authentication.getUsername() + ":" + authentication.getAccessKey() + "@ondemand.saucelabs.com:80/wd/hub"),
-                capabilities));
-        sessionId.set(((RemoteWebDriver) getWebDriver()).getSessionId().toString());
-        return webDriver.get();
-    }
-
     @Test(dataProvider = "hardCodedBrowsers")
     public void webDriver(String browser, String version, String os) throws Exception {
         WebDriver driver = createDriver(browser, version, os);
@@ -88,17 +50,4 @@ public class SampleSauceTest implements SauceOnDemandSessionIdProvider, SauceOnD
         driver.quit();
     }
 
-    public WebDriver getWebDriver() {
-        System.out.println("WebDriver" + webDriver.get());
-        return webDriver.get();
-    }
-
-    public String getSessionId() {
-        return sessionId.get();
-    }
-
-    @Override
-    public SauceOnDemandAuthentication getAuthentication() {
-        return authentication;
-    }
 }

--- a/testng/src/test/java/com/saucelabs/testng/SampleSauceTest.java
+++ b/testng/src/test/java/com/saucelabs/testng/SampleSauceTest.java
@@ -71,7 +71,7 @@ public class SampleSauceTest implements SauceOnDemandSessionIdProvider, SauceOnD
         DesiredCapabilities capabilities = new DesiredCapabilities();
         capabilities.setBrowserName(browser);
         capabilities.setCapability("version", version);
-        capabilities.setCapability("platform", Platform.extractFromSysProperty(os));
+        capabilities.setCapability("platform", os);
         webDriver.set(new RemoteWebDriver(
                 new URL("http://" + authentication.getUsername() + ":" + authentication.getAccessKey() + "@ondemand.saucelabs.com:80/wd/hub"),
                 capabilities));
@@ -83,8 +83,8 @@ public class SampleSauceTest implements SauceOnDemandSessionIdProvider, SauceOnD
     public void webDriver(String browser, String version, String os) throws Exception {
         WebDriver driver = createDriver(browser, version, os);
         logger.log(Level.INFO, "Running test using " + browser + " " + version + " " + os);
-        driver.get("http://www.amazon.com/");
-        assertEquals(driver.getTitle(), "Amazon.com: Online Shopping for Electronics, Apparel, Computers, Books, DVDs & more");
+        driver.get("https://saucelabs.com/test/guinea-pig");
+        assertEquals(driver.getTitle(), "I am a page title - Sauce Labs");
         driver.quit();
     }
 

--- a/testng/src/test/java/com/saucelabs/testng/SauceOnDemandListenerTest.java
+++ b/testng/src/test/java/com/saucelabs/testng/SauceOnDemandListenerTest.java
@@ -16,7 +16,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 
 
 /**
@@ -73,7 +72,7 @@ public class SauceOnDemandListenerTest extends SauceTestBase{
         String sessionId = null;
         String jobName = null;
         BufferedReader lineReader = new BufferedReader(new StringReader(output));
-        String line = null;
+        String line;
 
         try {
             while ((line = lineReader.readLine()) != null && sessionId == null && jobName == null) {

--- a/testng/src/test/java/com/saucelabs/testng/SauceOnDemandListenerTest.java
+++ b/testng/src/test/java/com/saucelabs/testng/SauceOnDemandListenerTest.java
@@ -1,0 +1,132 @@
+package com.saucelabs.testng;
+
+/**
+ * @author Mehmet Gerceker
+ */
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.openqa.selenium.WebDriver;
+import org.testng.ITestResult;
+import org.testng.annotations.*;
+
+import java.io.*;
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+/**
+ * Somewhat malformed TestNg test to test the test listener class.
+ * Capturing stdout from the test listener on success and failure requires test to complete,
+ * hence we need to validate test output after the test is run in the @AfterMethod function.
+ *
+ * @author Mehmet Gerceker
+ */
+@Listeners({SauceOnDemandTestListener.class})
+public class SauceOnDemandListenerTest extends SauceTestBase{
+
+
+    protected PrintStream stdoutStream;
+    protected ByteArrayOutputStream outputCapture;
+
+    @BeforeMethod
+    public void startOutputCapture() {
+        outputCapture = new ByteArrayOutputStream();
+        PrintStream outputStream = new PrintStream(outputCapture);
+        //back up the actual stdout
+        stdoutStream = System.out;
+        //set stdout to our stream
+        System.setOut(outputStream);
+    }
+
+    @AfterMethod
+    public void stopOutputCapture(ITestResult testResult) {
+        //Recover stdout
+        System.out.flush();
+        System.setOut(stdoutStream);
+        String output =  this.outputCapture.toString();
+        Pair<String, String> jobInfo = parseSessionIdJobName(output);
+        if(jobInfo.getLeft() == null ||
+            jobInfo.getLeft().toLowerCase().contentEquals("null")){
+            //this seems not to work well
+            testResult.setStatus(ITestResult.FAILURE);
+            //test has failed!
+            throw new AssertionError("SessionId is not valid!");
+        }
+        if(jobInfo.getRight() == null ||
+            jobInfo.getRight().toLowerCase().contentEquals("null")){
+            //this seems not to work well
+            testResult.setStatus(ITestResult.FAILURE);
+            //test has failed!
+            throw new AssertionError("job-name is not valid!");
+
+        }
+
+    }
+
+    protected Pair<String, String> parseSessionIdJobName(String output) {
+        Pattern sessionIdPattern = Pattern.compile("SauceOnDemandSessionID=([0-9a-fA-F]+)(?:.job-name=(.*))?");
+        String sessionId = null;
+        String jobName = null;
+        BufferedReader lineReader = new BufferedReader(new StringReader(output));
+        String line = null;
+
+        try {
+            while ((line = lineReader.readLine()) != null && sessionId == null && jobName == null) {
+                //make sure it is a possible match it can't be less than 32 chars
+                if (line == null || line.length() < 32) {
+                    continue;
+                }
+                Matcher m = sessionIdPattern.matcher(line);
+                while (m.find()) {
+                    //find the single line we need to find and get out.
+                    if (m.groupCount() == 2) {
+                        jobName = m.group(2);
+                        sessionId = m.group(1);
+                        break;
+                    }
+                }
+            }
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+
+        return Pair.of(sessionId, jobName);
+    }
+
+    /**
+     * Simple hard-coded DataProvider that explicitly sets the browser combination to be used.
+     *
+     * @param testMethod
+     * @return 2D Array of browser configs.
+     */
+    @DataProvider(name = "singleBrowser", parallel = false)
+    public static Object[][] sauceSingleBrowserDataProvider(Method testMethod) {
+        return new Object[][]{
+            new Object[]{"chrome", "43", "Windows 2012"}
+        };
+    }
+
+
+    @Test(dataProvider = "singleBrowser", expectedExceptions = AssertionError.class)
+    public void testSessionIdTestNameOutputFailure(String browser, String version, String os) throws Exception {
+        WebDriver driver = createDriver(browser, version, os);
+        logger.log(Level.INFO, "Running test using " + browser + " " + version + " " + os);
+        driver.get("https://saucelabs.com/test/guinea-pig");
+        assertEquals(driver.getTitle(), "This is not it!");
+        driver.quit();
+    }
+
+    @Test(dataProvider = "singleBrowser")
+    public void testSessionIdTestNameOutputSuccess(String browser, String version, String os) throws Exception {
+        WebDriver driver = createDriver(browser, version, os);
+        logger.log(Level.INFO, "Running test using " + browser + " " + version + " " + os);
+        driver.get("https://saucelabs.com/test/guinea-pig");
+        assertEquals(driver.getTitle(), "I am a page title - Sauce Labs");
+        driver.quit();
+    }
+}

--- a/testng/src/test/java/com/saucelabs/testng/SauceTestBase.java
+++ b/testng/src/test/java/com/saucelabs/testng/SauceTestBase.java
@@ -9,17 +9,11 @@ import com.saucelabs.common.SauceOnDemandSessionIdProvider;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
 
-import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static org.testng.Assert.assertEquals;
 
 
 /**

--- a/testng/src/test/java/com/saucelabs/testng/SauceTestBase.java
+++ b/testng/src/test/java/com/saucelabs/testng/SauceTestBase.java
@@ -1,0 +1,82 @@
+package com.saucelabs.testng;
+
+/**
+ * @author Ross Rowe
+ */
+
+import com.saucelabs.common.SauceOnDemandAuthentication;
+import com.saucelabs.common.SauceOnDemandSessionIdProvider;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Simple TestNG test which demonstrates being instantiated via a DataProvider in order to supply multiple browser combinations.
+ *
+ * @author Ross Rowe
+ */
+@Listeners({SauceOnDemandTestListener.class})
+public class SauceTestBase implements SauceOnDemandSessionIdProvider, SauceOnDemandAuthenticationProvider {
+
+    /**
+     * Constructs a {@link com.saucelabs.common.SauceOnDemandAuthentication} instance using the supplied user name/access key.  To use the authentication
+     * supplied by environment variables or from an external file, use the no-arg {@link com.saucelabs.common.SauceOnDemandAuthentication} constructor.
+     */
+    public SauceOnDemandAuthentication authentication = new SauceOnDemandAuthentication();
+
+    protected ThreadLocal<WebDriver> webDriver = new ThreadLocal<WebDriver>();
+
+    protected ThreadLocal<String> sessionId = new ThreadLocal<String>();
+
+    protected static final Logger logger = Logger.getLogger(SauceTestBase.class.getName());
+
+
+    /**
+     * Creates a new {@link RemoteWebDriver} instance which is configured
+     * @param browser
+     * @param version
+     * @param os
+     * @return
+     * @throws MalformedURLException
+     */
+    protected WebDriver createDriver(String browser, String version, String os) throws MalformedURLException {
+
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        capabilities.setBrowserName(browser);
+        capabilities.setCapability("version", version);
+        capabilities.setCapability("platform", os);
+        webDriver.set(new RemoteWebDriver(
+            new URL("http://" + authentication.getUsername() + ":" + authentication.getAccessKey() + "@ondemand.saucelabs.com:80/wd/hub"),
+            capabilities));
+        sessionId.set(((RemoteWebDriver) getWebDriver()).getSessionId().toString());
+        return webDriver.get();
+    }
+
+
+
+    public WebDriver getWebDriver() {
+        System.out.println("WebDriver" + webDriver.get());
+        return webDriver.get();
+    }
+
+    public String getSessionId() {
+        return sessionId.get();
+    }
+
+    @Override
+    public SauceOnDemandAuthentication getAuthentication() {
+        return authentication;
+    }
+}

--- a/testng/src/test/resources/xml/testng.xml
+++ b/testng/src/test/resources/xml/testng.xml
@@ -6,7 +6,8 @@
     <parameter name="browserVersion" value="3.6."/>
     <test name="WebDriver" >
         <classes>
-            <class name="com.saucelabs.testng.SampleSauceTest" />
+          <class name="com.saucelabs.testng.SampleSauceTest" />
+          <class name="com.saucelabs.testng.SauceOnDemandListenerTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION

Changes:
* Refactored the listener not to hold on to the SauceSessionIdProvider long term i.e. between the start and end of the test execution). -> The SauceSessionIdProvider was not declared ThreadSafe and therefore was susceptible to corruption.
* Removed SessionId print out from the onTestStart where there's no SessionId to be had. (The session id gets created in test setup or in the test. OnTestStart executes before any of those get executed. Moved it to onTestSuccess and onTestFailure where the information needed is available.
* Changed the title test target to saucelabs test page to make sure we're not at the mercy of amazon for this test to pass.

The reason for the changes:
* While running test methods in parallel on occasion the session id gets not set due to concurrency issues. These changes remedy those issues.
* The old code was making many errors, the changes make it so that unacceptable conditions i.e. no session id being set throw exceptions.

Unit tests ran and passed also tested with sample code and performed as it should. 

