### PR TITLE
Changing SauceRest version

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>com.saucelabs</groupId>
             <artifactId>saucerest</artifactId>
-            <version>1.0.32</version>
+            <version>1.0.37</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.saucelabs</groupId>
             <artifactId>saucerest</artifactId>
-            <version>1.0.32</version>
+            <version>1.0.37</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>

--- a/quickstart-archetype/pom.xml
+++ b/quickstart-archetype/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.saucelabs</groupId>
             <artifactId>saucerest</artifactId>
-            <version>1.0.32</version>
+            <version>1.0.37</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>

--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.saucelabs</groupId>
             <artifactId>saucerest</artifactId>
-            <version>1.0.32</version>
+            <version>1.0.37</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
The version number of SauceRest has been changed from 1.0.32 to 1.0.37 in
all locations.