### PR TITLE
Support different datacenter for sending sauce test result

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,5 +21,11 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.saucelabs</groupId>
+            <artifactId>saucerest</artifactId>
+            <version>1.0.40</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/junit/src/main/java/com/saucelabs/junit/SauceOnDemandTestWatcher.java
+++ b/junit/src/main/java/com/saucelabs/junit/SauceOnDemandTestWatcher.java
@@ -3,6 +3,7 @@ package com.saucelabs.junit;
 import com.saucelabs.common.SauceOnDemandAuthentication;
 import com.saucelabs.common.SauceOnDemandSessionIdProvider;
 import com.saucelabs.common.Utils;
+import com.saucelabs.saucerest.DataCenter;
 import com.saucelabs.saucerest.SauceREST;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
@@ -75,7 +76,20 @@ public class SauceOnDemandTestWatcher extends TestWatcher {
      */
     public SauceOnDemandTestWatcher(SauceOnDemandSessionIdProvider sessionIdProvider, final String username, final String accessKey, boolean verboseMode) {
         this.sessionIdProvider = sessionIdProvider;
-        sauceREST = new SauceREST(username, accessKey);
+        sauceREST = new SauceREST(username, accessKey, DataCenter.US);
+        this.verboseMode = verboseMode;
+    }
+
+    /**
+     * @param sessionIdProvider Id provider for the current web driver session
+     * @param username Sauce user name
+     * @param accessKey Sauce access key
+     * @param verboseMode Enables verbose mode
+     * @param dataCenter - data center for running test EU or US - US is default
+     */
+    public SauceOnDemandTestWatcher(SauceOnDemandSessionIdProvider sessionIdProvider, final String username, final String accessKey, boolean verboseMode, DataCenter dataCenter) {
+        this.sessionIdProvider = sessionIdProvider;
+        sauceREST = new SauceREST(username, accessKey, dataCenter);
         this.verboseMode = verboseMode;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.saucelabs</groupId>
             <artifactId>saucerest</artifactId>
-            <version>1.0.39</version>
+            <version>1.0.40</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>


### PR DESCRIPTION
Due to GDPR compliance, Sauce lab now support running test in EU and US data-center, By default, SauceRest sends results of tests passed or failed to US data center. 

Allow passing datacenter as an argument to send results to EU data center.

 